### PR TITLE
Add member role to the CMS

### DIFF
--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -9,8 +9,6 @@ services:
       - ./.env
     ports:
       - 8000:8000
-    volumes:
-      - /home/appdata/cms:/app/dist
 
   swag:
     image: lscr.io/linuxserver/swag:latest

--- a/backend/src/access/isAdmin.ts
+++ b/backend/src/access/isAdmin.ts
@@ -1,0 +1,22 @@
+import { Access, FieldAccess } from "payload/types";
+
+export interface User {
+    id: string;
+    name: string;
+    roles: ('admin' | 'member')[];
+    email?: string;
+    resetPasswordToken?: string;
+    resetPasswordExpiration?: string;
+    loginAttempts?: number;
+    lockUntil?: string;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export const isAdmin: Access<any, User> = ({ req: { user } }) => {
+  return Boolean(user?.roles?.includes('admin'));
+}
+
+export const isAdminFieldLevel: FieldAccess<{ id: string }, unknown, User> = ({ req: { user } }) => {
+  return Boolean(user?.roles?.includes('admin'));
+}

--- a/backend/src/collections/Categories.ts
+++ b/backend/src/collections/Categories.ts
@@ -1,4 +1,5 @@
 import { CollectionConfig } from "payload/types";
+import { isAdmin } from "../access/isAdmin";
 
 // * Blog or Announcement
 
@@ -10,6 +11,9 @@ const Categories: CollectionConfig = {
   },
   access: {
     read: () => true,
+    create: isAdmin,
+    update: isAdmin,
+    delete: isAdmin,
   },
   fields: [
     {

--- a/backend/src/collections/Media.ts
+++ b/backend/src/collections/Media.ts
@@ -1,9 +1,11 @@
 import { CollectionConfig } from "payload/types";
+import { isAdmin } from "../access/isAdmin";
 
 const Media: CollectionConfig = {
   slug: "media",
   access: {
     read: (): boolean => true,
+    delete: isAdmin,
   },
   admin: {
     useAsTitle: "title",

--- a/backend/src/collections/Posts.ts
+++ b/backend/src/collections/Posts.ts
@@ -1,4 +1,5 @@
 import { CollectionConfig } from "payload/types";
+import { isAdmin } from "../access/isAdmin";
 
 const Posts: CollectionConfig = {
   slug: "posts",
@@ -11,6 +12,7 @@ const Posts: CollectionConfig = {
     read: () => true,
     create: () => true,
     update: () => true,
+    delete: isAdmin,
   },
   fields: [
     {

--- a/backend/src/collections/Tags.ts
+++ b/backend/src/collections/Tags.ts
@@ -1,4 +1,5 @@
 import { CollectionConfig } from "payload/types";
+import { isAdmin } from "../access/isAdmin";
 
 // * Post tags like Misc, Informative, Dev, etc
 
@@ -10,6 +11,9 @@ const Tags: CollectionConfig = {
   },
   access: {
     read: () => true,
+    create: isAdmin,
+    update: isAdmin,
+    delete: isAdmin,
   },
   fields: [
     {

--- a/backend/src/collections/Users.ts
+++ b/backend/src/collections/Users.ts
@@ -1,4 +1,5 @@
 import { CollectionConfig } from "payload/types";
+import { isAdmin } from "../access/isAdmin";
 
 const Users: CollectionConfig = {
   slug: "users",
@@ -9,6 +10,9 @@ const Users: CollectionConfig = {
   },
   access: {
     read: () => true,
+    create: isAdmin,
+    update: isAdmin,
+    delete: isAdmin,
   },
   fields: [
     // * Email added by default

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/node": "18.11.18",
-    "@types/react": "18.0.26",
+    "@types/react": "18.0.27",
     "@types/react-dom": "18.0.4",
     "autoprefixer": "^10.4.7",
     "eslint": "8.15.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -236,7 +236,7 @@
 
 "@types/node@18.11.18":
   version "18.11.18"
-  resolved "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
   integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
 
 "@types/parse5@^6.0.0":
@@ -256,10 +256,19 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@18.0.26":
+"@types/react@*":
   version "18.0.26"
   resolved "https://registry.npmjs.org/@types/react/-/react-18.0.26.tgz"
   integrity sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@18.0.27":
+  version "18.0.27"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.27.tgz#d9425abe187a00f8a5ec182b010d4fd9da703b71"
+  integrity sha512-3vtRKHgVxu3Jp9t718R9BuzoD4NcQ8YJ5XRzsSKxNDiDonD2MXIT1TmSkenxuCycZJoQT5d2vE8LwWJxBC1gmA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -2743,7 +2752,7 @@ type-fest@^0.20.2:
 
 typescript@4.9.4:
   version "4.9.4"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 unbox-primitive@^1.0.2:


### PR DESCRIPTION
Resolves #26 

This PR adds a new kind of role to the User collection - the `member` role.
The member role is capable of the following operations
- CRU for `Media` and `Posts`
- R for `Tags`, `Users` and `Categories`
where CRU and R are a subset of CRUD